### PR TITLE
feature: testing gh actions on PR merges (destroying on merge)

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -4,7 +4,7 @@ name: 'Cleanup'
 
 on:
   pull_request:
-    types: [closed]
+    types: [edited]
 
 jobs:
   destroy_workspace:
@@ -16,6 +16,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: terraform destroy
-        uses: dflook/terraform-destroy@v1
+        uses: dflook/terraform-destroy-workspace@v1
         with:
+          variables: |
+            BRANCH = "${{ github.head_ref }}"
           workspace: ${{ github.head_ref }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -4,7 +4,7 @@ name: 'Cleanup'
 
 on:
   pull_request:
-    types: [edited]
+    types: [closed]
 
 jobs:
   destroy_workspace:


### PR DESCRIPTION
During #8 I noticed there was some var missing that didn't allow for a correct destroy of the workspace and its resources. Opening this PR to fix that by testing with some different triggers first.