### PR TITLE
Calling branchName

### DIFF
--- a/serve/routes/upload.js
+++ b/serve/routes/upload.js
@@ -65,7 +65,7 @@ router.post('/upload', validator.body(uploadSchema), validateContribution, async
       let contrib = req.files.contribution;
       const uploadParams = {
         Bucket: `mpc2`,
-        Key: `${branchName}/${circuit}/${name}.zkey`,
+        Key: `${branchName()}/${circuit}/${name}.zkey`,
         Body: contrib.data,
       };
 


### PR DESCRIPTION
Quick fix since `branchName` was being used instead of `branchName()` generating a very funny folder name in aws