### PR TITLE
Adding some terraform fixes for main branch

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -33,6 +33,18 @@ jobs:
           workspace: mpc
           auto_approve: true
 
+      - name: Set up S3cmd cli tool
+        uses: s3-actions/s3cmd@v1.2.0
+        with:
+          provider: aws # default is linode
+          region: 'eu-west-2'
+          access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Copy first contribution to new branch folder
+        run: |
+          s3cmd sync circuits/* s3://mpc-main --exclude="*.r1cs" --exclude="*.ptau"
+
   browser:
     strategy:
       matrix:

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -78,7 +78,7 @@ resource "aws_lb_listener" "listener" {
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = "arn:aws:acm:eu-west-3:950711068211:certificate/d5770f09-a98c-4800-8dd1-4e659541686a"
+  certificate_arn   = var.BRANCH == "main" ? "arn:aws:acm:eu-west-3:950711068211:certificate/2ec392a8-4e0c-4edc-a050-9b673cebcf88" : "arn:aws:acm:eu-west-3:950711068211:certificate/b26d35d0-219d-4883-91b5-686cdd2d5953"
 
   default_action {
     type             = "forward"

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -78,7 +78,7 @@ resource "aws_lb_listener" "listener" {
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = "arn:aws:acm:eu-west-3:950711068211:certificate/9fe98f88-975a-4484-9239-25ebcf4e0551"
+  certificate_arn   = "arn:aws:acm:eu-west-3:950711068211:certificate/d5770f09-a98c-4800-8dd1-4e659541686a"
 
   default_action {
     type             = "forward"

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -14,7 +14,6 @@ resource "aws_cloudfront_distribution" "distribution" {
     compress = false
     viewer_protocol_policy = "allow-all"
     allowed_methods  = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
-    cached_methods   = ["GET", "HEAD", "OPTIONS"]
     cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6" // default policy id
     origin_request_policy_id = "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf" // default policy id
     response_headers_policy_id = "5cc3b908-e619-4b99-88e5-2cf7f45965bd" // default policy id
@@ -22,7 +21,7 @@ resource "aws_cloudfront_distribution" "distribution" {
   }
 
   viewer_certificate {
-    acm_certificate_arn = "arn:aws:acm:us-east-1:950711068211:certificate/bf2723a4-6eb3-45a4-be75-f0032d712d7d"
+    acm_certificate_arn = "arn:aws:acm:us-east-1:950711068211:certificate/88833a3f-18be-4f5b-b56b-d88616abe242"
     ssl_support_method = "sni-only"
   }
 

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -14,6 +14,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     compress = false
     viewer_protocol_policy = "allow-all"
     allowed_methods  = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
+    cached_methods   = ["GET", "HEAD"]
     cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6" // default policy id
     origin_request_policy_id = "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf" // default policy id
     response_headers_policy_id = "5cc3b908-e619-4b99-88e5-2cf7f45965bd" // default policy id
@@ -21,7 +22,7 @@ resource "aws_cloudfront_distribution" "distribution" {
   }
 
   viewer_certificate {
-    acm_certificate_arn = "arn:aws:acm:us-east-1:950711068211:certificate/88833a3f-18be-4f5b-b56b-d88616abe242"
+    acm_certificate_arn = var.BRANCH == "main" ? "arn:aws:acm:us-east-1:950711068211:certificate/2ac0b0ce-2bc8-4e9c-8b01-4e292d5b7b57" : "arn:aws:acm:us-east-1:950711068211:certificate/efc3c9c7-f5bd-4506-aa9a-99e32675cd43"
     ssl_support_method = "sni-only"
   }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -57,7 +57,7 @@ variable "COMMITHASH" {
 
 resource "aws_instance" "mpc" {
   ami           = "ami-064736ff8301af3ee"
-  instance_type = "c7g.xlarge"
+  instance_type = "m6i.xlarge"
   user_data_base64 = base64encode("${templatefile("server.sh", {
       access_key_secret = var.AWS_SECRET_ACCESS_KEY
       access_key_id = var.AWS_ACCESS_KEY_ID

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -57,7 +57,7 @@ variable "COMMITHASH" {
 
 resource "aws_instance" "mpc" {
   ami           = "ami-064736ff8301af3ee"
-  instance_type = "t3.large"
+  instance_type = "c7g.xlarge"
   user_data_base64 = base64encode("${templatefile("server.sh", {
       access_key_secret = var.AWS_SECRET_ACCESS_KEY
       access_key_id = var.AWS_ACCESS_KEY_ID


### PR DESCRIPTION
- Turns out the certificate worked fine for branches but not for main. This has been fixed. `
- `OPTIONS` was also being cached by cloudfront which created some CORS problem.
- Increasing the number of CPUs on the EC2 instance to speed up verification process